### PR TITLE
fix error on null result, bump dependency ver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "soap-as-promised",
   "version": "1.6.0",
+  "version": "1.5.1",
   "description": "Convert all soap methods to promises. Inspired by soap-q.",
   "main": "soap-as-promised.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soap-as-promised",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Convert all soap methods to promises. Inspired by soap-q.",
   "main": "soap-as-promised.js",
   "scripts": {
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/warseph/soap-as-promised",
   "dependencies": {
-    "soap": "^0.9.5"
+    "soap": "^0.11.4"
   }
 }

--- a/soap-as-promised.js
+++ b/soap-as-promised.js
@@ -13,7 +13,7 @@ function cb2promise(fn, bind, position) {
         if (err) {
           reject(err);
         } else {
-          result._rawResponse = raw;
+          if (result) result._rawResponse = raw;
           resolve(result);
         }
       }


### PR DESCRIPTION
thanks for making this :+1:

while trying to work with the Web of Science SOAP API, i ran into 2 problems that i've fixed in this PR:
* newer versions of vpulim/node-soap allow to set HTTP-Headers on clients
* there was a TypeError thrown upon empty (but successful) SOAP responses