### PR TITLE
Added object check before adding raw response property

### DIFF
--- a/soap-as-promised.js
+++ b/soap-as-promised.js
@@ -16,7 +16,9 @@ function cb2promise(fn, bind, position) {
           if (!result) {
             result = {return: null};
           }
-          result._rawResponse = raw;
+          if (typeof result === "object") {
+            result._rawResponse = raw;
+          }
           resolve(result);
         }
       }


### PR DESCRIPTION
If soap method does not return an object the existing implementation fails because trying to add a prototype/field to a value type (i.e. string).   So that an existing soap user can wrap with soap-as-promised ok, I've kept the return value as-is rather than creating a wrapper object (like with null values).