### PR TITLE
handle case of string-only response

### DIFF
--- a/soap-as-promised.js
+++ b/soap-as-promised.js
@@ -16,6 +16,9 @@ function cb2promise(fn, bind, position) {
           if (!result) {
             result = {return: null};
           }
+          if (typeof result !== 'object') {
+            result = { return: result };
+          }
           result._rawResponse = raw;
           resolve(result);
         }

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -13,6 +13,8 @@ const RESPONSE_XML = __dirname + '/files/response.xml';
 const RESPONSE = fs.readFileSync(RESPONSE_XML).toString().trim();
 const EMPTY_RESPONSE_XML = __dirname + '/files/empty-response.xml';
 const EMPTY_RESPONSE = fs.readFileSync(EMPTY_RESPONSE_XML).toString().trim();
+const STRING_RESPONSE_XML = __dirname + '/files/string-response.xml';
+const STRING_RESPONSE = fs.readFileSync(STRING_RESPONSE_XML).toString().trim();
 const HOST = 'localhost';
 const PORT = 65534;
 const BASE_URL = `http://${HOST}:${PORT}`;
@@ -71,6 +73,27 @@ describe('Promisified client', function() {
       .then(r => r._rawResponse.trim());
 
       return expect(rawResponse).to.eventually.eq(EMPTY_RESPONSE);
+    });
+  });
+
+  describe('String response', function () {
+    before(function (done) {
+      server = http.createServer(function (req, res) {
+        res.statusCode = 200;
+        res.write(STRING_RESPONSE, 'utf8');
+        res.end();
+      });
+      server.listen(PORT, HOST, done);
+    });
+    after(function (done) {
+      server.close(done);
+    });
+    it('should wrap the string in an object if it is a string response', function () {
+      const rawResponse = soap.createClient(WSDL, {}, BASE_URL)
+      .then(c => c.MyOperation({}))
+      .then(r => r._rawResponse.trim());
+
+      return expect(rawResponse).to.eventually.eq(STRING_RESPONSE);
     });
   });
 

--- a/test/files/string-response.xml
+++ b/test/files/string-response.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2001/12/soap-envelope" SOAP-ENV:encodingStyle="http://www.w3.org/2001/12/soap-encoding" >
+   <SOAP-ENV:Body xmlns:m="http://www.xyz.org/quotation" >
+      <m:MyOperationResponse>Test response</m:MyOperationResponse>
+   </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
As [previously noted](https://github.com/warseph/soap-as-promised/pull/9), soap-as-promised fails if the host returns a plain string with no wrapping object.

Here is a better fix along with a test ;)