### PR TITLE
Security fix - soap last version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/warseph/soap-as-promised",
   "dependencies": {
-    "soap": "^0.26.0"
+    "soap": "^0.43.0"
   },
   "devDependencies": {
     "eslint": "^5.14.1",


### PR DESCRIPTION
Updated to the last soap version dependency.
"soap": "^0.43.0"
Should solve the soap  <--  xml-crypto  <-- xmldom high vulnerability issues.